### PR TITLE
Add JWT token endpoint for SSO integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,34 @@ An example admin user is included:
 ```
 
 After logging in with an admin account you can manage users at `/admin`.
+
+### Integrating with SI-Kepegawaian
+
+Applications can obtain a signed JWT for the currently logged in user via
+`/token`. Pass the target application ID in the `app` query string, e.g.:
+
+```
+GET /token?app=kepegawaian
+```
+
+If the user is allowed access, a JSON response like the following will be
+returned:
+
+```json
+{"token":"<jwt-token>"}
+```
+
+The token is signed using the secret defined by `jwt.secret` in `.env`. The
+SI-Kepegawaian project can verify this token using the `firebase/php-jwt`
+library:
+
+```php
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+
+$data = JWT::decode($token, new Key(getenv('JWT_SECRET'), 'HS256'));
+```
+
+The decoded payload contains the user's email and name. Implement a login route
+in SI-Kepegawaian that accepts the token, verifies it, and starts a session for
+the corresponding user.

--- a/sso/app/Config/Applications.php
+++ b/sso/app/Config/Applications.php
@@ -22,7 +22,7 @@ class Applications extends BaseConfig
             'label' => 'Sistem Informasi Kepegawaian',
             'icon'  => 'fas fa-id-badge',
             'color' => 'success',
-            'url'   => '#',
+            'url'   => 'http://localhost:8080/sso-login',
         ],
     ];
 }

--- a/sso/app/Config/Routes.php
+++ b/sso/app/Config/Routes.php
@@ -9,6 +9,7 @@ $routes->get('/', 'Home::index');
 $routes->get('login', 'Auth::login');
 $routes->get('callback', 'Auth::callback');
 $routes->get('logout', 'Auth::logout');
+$routes->get('token', 'Auth::token');
 
 $routes->group('admin', ['filter' => 'admin'], static function ($routes) {
     $routes->get('/', 'Admin::index');

--- a/sso/composer.json
+++ b/sso/composer.json
@@ -13,7 +13,8 @@
         "php": "^8.1",
         "almasaeed2010/adminlte": "^3.2",
         "codeigniter4/framework": "^4.0",
-        "google/apiclient": "^2.15"
+        "google/apiclient": "^2.15",
+        "firebase/php-jwt": "^6.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9",

--- a/sso/composer.lock
+++ b/sso/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7353fb9164c1b8d10d46341de534c79f",
+    "content-hash": "b0a6398c61c4096032b3af7dc6ea46d1",
     "packages": [
         {
             "name": "almasaeed2010/adminlte",
@@ -3251,12 +3251,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.1"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/sso/env
+++ b/sso/env
@@ -71,3 +71,6 @@
 # Google OAuth
 google.oauthClientId="YOUR_GOOGLE_CLIENT_ID"
 google.oauthClientSecret="YOUR_GOOGLE_CLIENT_SECRET"
+
+# Secret key used for signing JWT tokens issued to applications
+jwt.secret="CHANGE_ME"


### PR DESCRIPTION
## Summary
- add `/token` endpoint to issue JWT for logged user
- store JWT secret in `.env`
- document how to verify tokens from SI-Kepegawaian
- update kepegawaian URL in Applications config
- require `firebase/php-jwt`

## Testing
- `composer install --working-dir=sso`
- `composer test --working-dir=sso`

------
https://chatgpt.com/codex/tasks/task_e_6882cb5d7a4c832fbb6775fe79c2397b