### PR TITLE
Handle missing JWT secret

### DIFF
--- a/sso/app/Controllers/Auth.php
+++ b/sso/app/Controllers/Auth.php
@@ -69,7 +69,10 @@ class Auth extends Controller
             'app'  => $appId,
             'iat'  => time(),
         ];
-        $secret = env('jwt.secret');
+        $secret = env('jwt.secret') ?: getenv('JWT_SECRET');
+        if (! is_string($secret) || $secret === '') {
+            throw new \RuntimeException('JWT secret is not configured');
+        }
         $token  = \Firebase\JWT\JWT::encode($payload, $secret, 'HS256');
 
         return $this->response->setJSON(['token' => $token]);
@@ -102,7 +105,10 @@ class Auth extends Controller
             'app'  => $appId,
             'iat'  => time(),
         ];
-        $secret = env('jwt.secret');
+        $secret = env('jwt.secret') ?: getenv('JWT_SECRET');
+        if (! is_string($secret) || $secret === '') {
+            throw new \RuntimeException('JWT secret is not configured');
+        }
         $token  = \Firebase\JWT\JWT::encode($payload, $secret, 'HS256');
 
         $target = rtrim($config->apps[$appId]['url'], '/');


### PR DESCRIPTION
## Summary
- avoid InvalidArgumentException from firebase/php-jwt when the jwt secret env value is missing
- throw a RuntimeException when no JWT secret is configured

## Testing
- `composer --working-dir=sso test`

------
https://chatgpt.com/codex/tasks/task_e_6882d5bd055c832f98179678868d9aeb