### PR TITLE
Fix README to mention JWT secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@ This repository contains a simple Single Sign-On (SSO) server built with **CodeI
    ```bash
    ln -s ../vendor sso/public/vendor
    ```
-4. Copy `sso/env` to `sso/.env` and fill in your Google OAuth credentials:
+4. Copy `sso/env` to `sso/.env` and fill in your Google OAuth credentials.
+   Set `jwt.secret` to any random string that will be used to sign the issued
+   tokens:
    ```ini
    google.oauthClientId="YOUR_GOOGLE_CLIENT_ID"
    google.oauthClientSecret="YOUR_GOOGLE_CLIENT_SECRET"
+   jwt.secret="YOUR_JWT_SECRET"
    ```
 5. Run the development server:
    ```bash


### PR DESCRIPTION
## Summary
- clarify the setup instructions about configuring `jwt.secret`

## Testing
- `composer install --working-dir=sso`
- `vendor/bin/phpunit -c phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_e_6882d8009044832fa506ce4687a674d1